### PR TITLE
docs(developer): add a developer playbook intro

### DIFF
--- a/content/developer/_index.md
+++ b/content/developer/_index.md
@@ -4,15 +4,15 @@ weight: 2
 layout: playbook
 ---
 
-The OMSF Developer Playbook is a comprehensive guide designed to help scientists and developers create high-quality, maintainable software for the scientific community. This playbook provides practical guidance on best practices that can be adopted at various stages of your project's lifecycle, from inception through long-term maintenance.
+The OMSF Developer Playbook is a comprehensive guide designed to help scientists and developers create high-quality, maintainable software. This playbook provides practical guidance on best practices that can be adopted at various stages of your project's lifecycle, from inception through long-term maintenance.
 
 ## Purpose and Audience
 
-Our primary goal is to increase developer literacy within the scientific community. By sharing established best practices, we aim to raise the overall quality of software in the space, leading to more reliable, reproducible, and usable scientific tools.
+Our primary goal is to increase developer literacy for developers! By sharing established best practices, we aim to raise the overall quality of software in the space, leading to more reliable, reproducible, and usable scientific tools.
 
 This playbook is intended for:
 - Scientists developing software for their research
-- Developers working on scientific applications
+- Developers working on applications
 - Teams of all sizes, from individual researchers to large collaborative projects
 - Practitioners at all skill levels, from beginners to experienced developers
 
@@ -29,4 +29,4 @@ Each section of the playbook focuses on a specific aspect of software developmen
 
 Rather than applying every practice at once, consider your project's specific needs and maturity level. The playbook indicates when each practice is most relevant (Inception, Early Development, Mid-Development, Pre-Release, Release, Post-Release, or Long term), helping you prioritize your efforts appropriately.
 
-By progressively adopting these practices, you'll build scientific software that's not only functional but also sustainable, accessible, and trustworthy for the broader scientific community.
+By progressively adopting these practices, you'll build software that's not only functional but also sustainable, accessible, and trustworthy your broader community.

--- a/content/developer/_index.md
+++ b/content/developer/_index.md
@@ -4,3 +4,29 @@ weight: 2
 layout: playbook
 ---
 
+The OMSF Developer Playbook is a comprehensive guide designed to help scientists and developers create high-quality, maintainable software for the scientific community. This playbook provides practical guidance on best practices that can be adopted at various stages of your project's lifecycle, from inception through long-term maintenance.
+
+## Purpose and Audience
+
+Our primary goal is to increase developer literacy within the scientific community. By sharing established best practices, we aim to raise the overall quality of software in the space, leading to more reliable, reproducible, and usable scientific tools.
+
+This playbook is intended for:
+- Scientists developing software for their research
+- Developers working on scientific applications
+- Teams of all sizes, from individual researchers to large collaborative projects
+- Practitioners at all skill levels, from beginners to experienced developers
+
+## How to Use This Playbook
+
+Each section of the playbook focuses on a specific aspect of software development, such as documentation, testing, code style, or performance. Within each section, you'll find concrete practices that you can implement, with guidance on:
+
+- What the practice entails
+- Why it's valuable for scientific software
+- When in your project's lifecycle to implement it
+- Implementation options with their advantages and disadvantages
+- Recommendations based on community experience
+- Resources for further learning
+
+Rather than applying every practice at once, consider your project's specific needs and maturity level. The playbook indicates when each practice is most relevant (Inception, Early Development, Mid-Development, Pre-Release, Release, Post-Release, or Long term), helping you prioritize your efforts appropriately.
+
+By progressively adopting these practices, you'll build scientific software that's not only functional but also sustainable, accessible, and trustworthy for the broader scientific community.


### PR DESCRIPTION
This PR adds a minimal intro for what to expect in the developer playbook.
