### PR TITLE
docs(developer): add repository structure section

### DIFF
--- a/content/developer/repository-structure/_index.md
+++ b/content/developer/repository-structure/_index.md
@@ -1,0 +1,15 @@
+---
+title: Repository Structure
+layout: topic
+---
+This section covers best practices for organizing your scientific software repository. A well-structured repository makes your code more approachable, easier to navigate, and simpler to maintain.
+
+## What You'll Learn
+
+In this section, you'll discover:
+
+- **Documentation organization**: Where to place your documentation for maximum visibility and usability
+- **Source code layout options**: The pros and cons of src-layout versus flat-layout structures
+- **Test organization**: How to decide whether tests should be included in your module or kept separate
+
+The repository structure decisions you make early in your project can have long-lasting impacts on development workflow, packaging, and testing. This section will help you make choices that align with community standards and support your specific project needs.

--- a/content/developer/repository-structure/determine-if-you-will-include-tests-in-your-module.md
+++ b/content/developer/repository-structure/determine-if-you-will-include-tests-in-your-module.md
@@ -1,0 +1,40 @@
+---
+layout: practice
+weight: 3
+title: Determine if you will include your tests in the module or not
+what: >
+  In Python, you can opt to include your tests into your released module or opt to keep them external
+why: >
+  Choosing whether your tests are internal or external allows for end-users to have the capability to have access to tests on installation. Excluding your tests keeps the package size small.
+when: Inception
+importance: High
+see_also:
+  - "[pytest good practices for test layouts](https://docs.pytest.org/en/stable/explanation/goodpractices.html#choosing-a-test-layout)"
+---
+
+When structuring your Python package, you need to decide whether tests will be included as part of the installable package or kept separate:
+
+**Tests inside the package**:
+```
+mypackage/
+├── __init__.py
+├── module.py
+└── tests/
+    ├── __init__.py
+    └── test_module.py
+```
+
+**Tests outside the package**:
+```
+repository/
+├── mypackage/
+│   ├── __init__.py
+│   └── module.py
+└── tests/
+    └── test_module.py
+```
+
+Including tests in your package makes them available to end-users, which can be helpful for verifying installation or understanding usage. However, it increases the package size and may unnecessarily bloat installations.
+
+External tests keep your package smaller and create a clearer separation between production code and test code, but users won't have direct access to the tests after installation.
+

--- a/content/developer/repository-structure/pick-a-location-for-your-docs.md
+++ b/content/developer/repository-structure/pick-a-location-for-your-docs.md
@@ -9,7 +9,7 @@ why: >
 when: Inception
 recommendation: Use a top-level docs directory as mentioned in the pip docs
 see_also:
-  - "[Pip Package Anatomy](https://pip.pypa.io/en/stable/development/architecture/anatomy/)"
+  - "[Pip Repository Anatomy](https://pip.pypa.io/en/stable/development/architecture/anatomy/)"
 ---
 
 When starting a new project, it's important to decide where documentation will live within your repository structure. Having a consistent location makes it easier for users and contributors to find the information they need.

--- a/content/developer/repository-structure/pick-a-location-for-your-docs.md
+++ b/content/developer/repository-structure/pick-a-location-for-your-docs.md
@@ -1,0 +1,17 @@
+---
+layout: practice
+weight: 1
+title: Pick a location for your docs
+what: >
+  You will want a location to hold all of the docs-related items, pick where that location fits
+why: >
+  This ensures that your docs are easily accessible by end-users
+when: Inception
+recommendation: Use a top-level docs directory as mentioned in the pip docs
+see_also:
+  - "[Pip Package Anatomy](https://pip.pypa.io/en/stable/development/architecture/anatomy/)"
+---
+
+When starting a new project, it's important to decide where documentation will live within your repository structure. Having a consistent location makes it easier for users and contributors to find the information they need.
+
+A common practice is to use a top-level `docs/` directory to store all documentation-related files, including user guides, API references, and developer guidelines. This approach is recommended by many Python projects and packaging tools.

--- a/content/developer/repository-structure/use-a-src-or-flat-layout.md
+++ b/content/developer/repository-structure/use-a-src-or-flat-layout.md
@@ -1,0 +1,38 @@
+---
+layout: practice
+weight: 2
+title: Use a src or flat layout
+what: >
+  A src layout is a project that uses a src directory to house code whereas a flat layout is where the source files are in the root of the directory
+why: >
+  The choice of layout impacts how your package is built, tested, and installed
+when: Inception
+importance: High
+see_also:
+  - "[`src` layout vs flat layout discussion](https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/)"
+---
+
+When organizing your Python package, you need to decide between a src layout or a flat layout:
+
+**Src Layout**: Your package code is housed in a `src/` directory:
+```
+myproject/
+├── src/
+│   └── mypackage/
+│       ├── __init__.py
+│       └── module.py
+├── tests/
+└── setup.py
+```
+
+**Flat Layout**: Your package code is directly in the project root:
+```
+myproject/
+├── mypackage/
+│   ├── __init__.py
+│   └── module.py
+├── tests/
+└── setup.py
+```
+
+Each has its advantages, but the src layout is often preferred for larger projects as it helps avoid import confusion during development and makes it easier to have a clear separation between installed code and development files.


### PR DESCRIPTION
This PR adds the "Repository Structure" section of the developer playbook. I have added some descriptions to aid with explaining some of the layout since it can be difficult to visualize without seeing it.
