### PR TITLE
Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+/content/developer/  @ethanholz @dwhswenson
+/content/contributions/ @dwhswenson @ethanholz


### PR DESCRIPTION
[CODEOWNERS files](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) allow us to automatically request reviews from certain people who are considered the "owners" of a part of the repository. My recommendation is to have a primary and secondary owner for each playbook. There's no way in the CODEOWNERS file to distinguish who is primary vs. secondary, but we can make the convention that the person listed first is primary.

As an example, I'm starting with a CODEOWNERS file with:

* **Developers**: primary: @ethanholz secondary: @dwhswenson 
* **Contributions**: primary: @dwhswenson secondary @ethanholz 