### PR TITLE
Layout updates: Simple Implementations

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,1 +1,2 @@
 https://www.atlassian.com/software/jira
+https://valgrind.org/

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -271,6 +271,11 @@ section.frontmatter {
     content: ":";
 }
 
+div .implementations {
+    margin-top: 0.5em;
+    margin-bottom: 0.5em;
+}
+
 .implementation {
     border: 1px solid #ccc;
     margin-left: 1em;

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -252,14 +252,21 @@ article {
 /* practice pages */
 section.frontmatter {
     border: 1px solid #ccc;
-    padding: 1em;
+    padding-top: 1em;
+    padding-left: 1em;
+    padding-right: 1em;
+    padding-bottom: 0em;  /* each frontmatter-section has bottom margin */
     margin: 1em;
 }
 
 .frontmatter-section {
+    width: 100%;
+    margin-bottom: 1em;
+}
+
+.required {
     display: grid;
     grid-template-columns: 6em 1fr;
-    width: 100%;
 }
 
 .frontmatter-section .label {
@@ -275,14 +282,14 @@ section.frontmatter {
     content: ":";
 }
 
-div .implementations {
-    margin-top: 0.5em;
-    margin-bottom: 0.5em;
+div .frontmatter-title {
+    width: 100%;
 }
 
 ul.implementations div.implementation {
-    border: 1px solid #ccc;
+    margin-top: 0.5em;
     margin-left: 1em;
+    padding: 0.5em;
 }
 
 ul.implementations-simple {

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -219,6 +219,7 @@ article {
 }
 
 .disadvantages {
+    margin-left: 1em;
     flex: 1;
 }
 
@@ -228,7 +229,10 @@ article {
     }
     .advantages {
         margin-right: 0;
-        margin-left: 0;
+        margin-left: 1em;
+    }
+    .disadvantages {
+        margin-left: 1em;
     }
 }
 
@@ -276,12 +280,17 @@ div .implementations {
     margin-bottom: 0.5em;
 }
 
-.implementation {
+ul.implementations div.implementation {
     border: 1px solid #ccc;
     margin-left: 1em;
 }
 
-.implementation:nth-child(odd) div {
+ul.implementations-simple {
+    list-style: initial;;
+    padding-left: 1.5em;
+}
+
+ul.implementations li:nth-child(odd) div {
     background: var(--striping-color);
 }
 

--- a/content/contributions/quiz.md
+++ b/content/contributions/quiz.md
@@ -1,6 +1,0 @@
----
-title: Quiz and Badge
-layout: quiz
-badge_name: OMSF Contributions Best Practices
----
-

--- a/layouts/_default/practice.html
+++ b/layouts/_default/practice.html
@@ -9,13 +9,9 @@
       </section>
       <h2>{{ .Title }}</h2>
       <section class="frontmatter">
-        <div class="frontmatter-section">
+        <div class="frontmatter-section required">
           <div class="label">What</div><div class="values">{{ .Params.what }}</div>
-        </div>
-        <div class="frontmatter-section">
           <div class="label">Why</div><div class="values">{{ .Params.why }}</div>
-        </div>
-        <div class="frontmatter-section">
           <div class="label">When</div><div class="values">{{ .Params.when }}</div>
         </div>
 
@@ -43,7 +39,8 @@
       {{ end }}
       {{ end }}
 
-      <div class="implementations"><b>Implementations:</b>
+      <div class="implementations frontmatter-section">
+      <b>Implementations:</b>
       <ul class="{{ $.Scratch.Get "ulclassname" }}">
         {{ range $impl := .Params.implementations }}
         <li><div class="implementation">
@@ -58,13 +55,13 @@
       {{ end }}
 
       {{ if .Params.recommendation }}
-      <div class="recommendation"><b>Recommendation:</b>
+      <div class="recommendation frontmatter-section"><b>Recommendation:</b>
       {{ .Params.recommendation }}
       </div>
       {{ end }}
 
       {{ if .Params.see_also }}
-      <div class="see-also"><b>See also:</b>
+      <div class="see-also frontmatter-section"><b>See also:</b>
       <ul>
       {{ range $also := .Params.see_also }}
         <li>{{ $also | markdownify }}</li>
@@ -74,7 +71,7 @@
       {{ end }}
 
       {{ if .Params.note }}
-      <div class="note"><i>Note:</i> {{ .Params.note }}</div>
+      <div class="note frontmatter-section"><i>Note:</i> {{ .Params.note }}</div>
       {{ end }}
   </section>
   <section class="content">

--- a/layouts/_default/practice.html
+++ b/layouts/_default/practice.html
@@ -33,17 +33,24 @@
       {{ end }}
 
       {{ if .Params.implementations }}
+
+      {{/* figure out if we have details or not */}}
+      {{ $.Scratch.Set "ulclassname" "implementations-simple" }}
+        {{ range .Params.implementations }}
+        {{ if or .advantages .disadvantages }}
+        {{ $.Scratch.Set "ulclassname" "implementations" }}
+        {{ end }}
+      {{ end }}
+
       <div class="implementations"><b>Implementations:</b>
-      {{/* hasAdv might not longer be needed */}}
-      {{ $hasAdv := where .Params.implementations "isset advantages" true }}
-        <ul class="implementations">
+      <ul class="{{ $.Scratch.Get "ulclassname" }}">
         {{ range $impl := .Params.implementations }}
-          <div class="implementation">
+        <li><div class="implementation">
             <div class="impl-desc">{{ $impl.desc | markdownify }}</div>
             {{ if (or $impl.advantages $impl.disadvantages) }}
             {{ partial "advantages-disadvantages.html" $impl }}
             {{ end }}
-          </div>
+            </div></li>
         {{ end }}
         </ul>
       </div>


### PR DESCRIPTION
These some updates for layouts and CSS, especially around the "Implementations" on practice pages.

* Adds an `implementations-simple` class that gives a normal `ul` style for cases where implementations lists don't include advantages and disadvantages
* Adds a little spacing around the implementations div (previously seemed a bit crowded to both top and bottom
* Adds a bit more spacing between advantages/disadvantages when they're side-by-side
* Removes the contributions quiz (can easily be added back later)

These are CSS/layout changes for the existing site, in advance of changes to match this to OMSF styles.